### PR TITLE
Problems with docker network configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,6 @@ help: ## Show this help message
 	@egrep '^(.+)\:\ ##\ (.+)' ${MAKEFILE_LIST} | column -t -c 2 -s ':#'
 
 start: ## Start the containers
-	docker network create ${DOCKER_BE}-network || true
 	cp -n docker-compose.yml.dist docker-compose.yml || true
 	U_ID=${UID} docker-compose up -d
 
@@ -21,7 +20,6 @@ restart: ## Restart the containers
 	$(MAKE) stop && $(MAKE) start
 
 build: ## Rebuilds all the containers
-	docker network create ${DOCKER_BE}-network || true
 	cp -n docker-compose.yml.dist docker-compose.yml || true
 	U_ID=${UID} docker-compose build
 

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ help: ## Show this help message
 	@egrep '^(.+)\:\ ##\ (.+)' ${MAKEFILE_LIST} | column -t -c 2 -s ':#'
 
 start: ## Start the containers
-	docker network create symfony-network || true
+	docker network create ${DOCKER_BE}-network || true
 	cp -n docker-compose.yml.dist docker-compose.yml || true
 	U_ID=${UID} docker-compose up -d
 
@@ -21,7 +21,7 @@ restart: ## Restart the containers
 	$(MAKE) stop && $(MAKE) start
 
 build: ## Rebuilds all the containers
-	docker network create symfony-network || true
+	docker network create ${DOCKER_BE}-network || true
 	cp -n docker-compose.yml.dist docker-compose.yml || true
 	U_ID=${UID} docker-compose build
 

--- a/docker-compose.yml.dist
+++ b/docker-compose.yml.dist
@@ -40,6 +40,8 @@ services:
 
 networks:
   symfony-app-network:
+    name: symfony-app-network
+    external: true
 
 volumes:
   symfony-app-mysql-data:

--- a/docker-compose.yml.dist
+++ b/docker-compose.yml.dist
@@ -41,7 +41,6 @@ services:
 networks:
   symfony-app-network:
     name: symfony-app-network
-    external: true
 
 volumes:
   symfony-app-mysql-data:


### PR DESCRIPTION
## Docker network name

When I tried to make a _find & replace_ to change the project name, the docker network generated by the Makefile didn't change. This PR fixes this issue 🙌

## Container in wrong network

Docker compose was creating a network because the configuration to make the containers connect to the network that we create with the Makefile was missing, here you can see the two network created with the `make start`:
<img width="600" alt="SCR-20240210-bjqy" src="https://github.com/codenip-tech/symfony-base-repository/assets/62360034/c2f6dd8c-cd4a-4c1c-99dd-6d456e19e206">

With the fix, docker compose use the network created in the Makefile and attach the containers properly:
<img width="600" alt="SCR-20240210-bkzi" src="https://github.com/codenip-tech/symfony-base-repository/assets/62360034/cee16298-fff1-4618-a17d-1247f67fbc67">
