### PR TITLE
Improve help target output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ help: ## Show this help message
 	@echo 'usage: make [target]'
 	@echo
 	@echo 'targets:'
-	@egrep '^(.+)\:\ ##\ (.+)' ${MAKEFILE_LIST} | column -t -c 2 -s ':#'
+	@egrep '^(.+)\:\ ##\ (.+)' ${MAKEFILE_LIST} | while read -r l; do printf "\033[1;32m$$(echo $$l | cut -f 1 -d':')\033[00m:$$(echo $$l | cut -f 2- -d'#')\n"; done | column -t -c 2 -s ':#'
 
 start: ## Start the containers
 	cp -n docker-compose.yml.dist docker-compose.yml || true


### PR DESCRIPTION
Change the target color in the auto-generated `help` target output:

<img width="600" alt="image" src="https://github.com/codenip-tech/symfony-base-repository/assets/62360034/79fd1a52-db72-4dda-b1ad-12aa7916b854">
