### PR TITLE
`sf` alias don't work

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,7 +7,7 @@ RUN adduser -u ${UID} --disabled-password --gecos "" appuser
 RUN mkdir /home/appuser/.ssh
 RUN chown -R appuser:appuser /home/appuser/
 RUN echo "StrictHostKeyChecking no" >> /home/appuser/.ssh/config
-RUN echo "alias sf=/appdata/www/bin/console" >> /home/appuser/.bashrc
+RUN echo "alias sf=/var/www/html/bin/console" >> /home/appuser/.bashrc
 
 # Install packages and PHP extensions
 RUN apt update \


### PR DESCRIPTION
Due to the change to Apache web server and use of the default path were that web server read files the `sf` alias stop working:
<img width="600" alt="image" src="https://github.com/codenip-tech/symfony-base-repository/assets/62360034/59a9d4b7-3354-4953-a917-2e4cac625861">

With this quick fix the alias will work again:
<img width="600" alt="image" src="https://github.com/codenip-tech/symfony-base-repository/assets/62360034/e29714fd-e9a7-4ab6-9a0a-657f0bc4cfc6">
